### PR TITLE
Updates tracking methods that we accept on the Reverb side

### DIFF
--- a/Reverb/ReverbSync/Model/Sync/Shipment/Tracking.php
+++ b/Reverb/ReverbSync/Model/Sync/Shipment/Tracking.php
@@ -37,6 +37,23 @@ class Tracking extends \Reverb\ProcessQueue\Model\Task
         'ups' => 'UPS',
         'usps' => 'USPS',
         'canada_post' => 'Canada Post',
+        'dpd_uk' => 'DPD UK',
+        'dpd_france' => 'DPD France',
+        'dpd_germany' => 'DPD Germany',
+        'ukraine_post' => 'Ukraine Post',
+        'correos_espana' => 'Correos España',
+        'interlogistica' => 'Interlogistica',
+        'purolator' => 'Purolator',
+        'parcelforce' => 'Parcelforce',
+        'china_post' => 'China Post',
+        'la_poste' => 'La Poste',
+        'gls' => 'GLS',
+        'ems' => 'EMS',
+        'australia_post' => 'Australia Post',
+        'post_nl' => 'PostNL',
+        'royal_mail' => 'Royal Mail',
+        'dhl_deutschland' => 'DHL Deutschland',
+        'dhl_express' => 'DHLExpress',
     );
 
     public function transmitTrackingDataToReverb($argumentsObject)


### PR DESCRIPTION
https://trello.com/c/mCTluxmY/2631-dpd-uk-tracking-information-not-updating-properly-via-api-and-magento

## What
Adds all the currently supported shipping providers to the magento -> reverb mapping

## Why
Users can't attach shipping for anything outside the small supported list

We should consider making this pass through if we don't "support" the given provider, which should future proof this list a bit more.